### PR TITLE
Fix: Add import for shims and angular2 pollyfills to index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,10 @@
+import 'es5-shim';
+import 'es6-shim';
+import 'es6-promise';
+import '../shims/shims_for_IE';
+
+import 'angular2/bundles/angular2-polyfills';
+
 import { enableProdMode, provide } from 'angular2/core';
 import { bootstrap } from 'angular2/platform/browser';
 import { ROUTER_PROVIDERS, APP_BASE_HREF } from 'angular2/router';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,13 +75,6 @@ const postcssPlugins = postcssBasePlugins
 module.exports = {
   entry: {
     app: './src/index.ts',
-    shims: [
-      'es5-shim',
-      'es6-shim',
-      'es6-promise',
-      './shims/shims_for_IE'
-    ],
-    ng2polyfills: 'angular2/bundles/angular2-polyfills'
   },
 
   output: {


### PR DESCRIPTION
Removed shims and polyfills from webpack config and added explicit imports to index.ts to ensure the shims and angular2 polyfills load before angular does. 

Tested updated version on Chrome and IE and the buttons load correctly now (when switching between About Us and Counter page)

Connected to rangle/rangle-starter#100
