### PR TITLE
Fix the code coverage report to include files that are not require'd by .test.ts files, so that the numbers are now correct

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,6 +2,7 @@
 
 const loaders = require('./webpack/loaders');
 const postcssInit = require('./webpack/postcss');
+const plugins = require('./webpack/plugins');
 
 module.exports = (config) => {
   config.set({
@@ -55,7 +56,7 @@ module.exports = (config) => {
       },
       stats: { colors: true, reasons: true },
       debug: false,
-      plugins: [],
+      plugins: plugins,
       postcss: postcssInit,
     },
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -54,7 +54,7 @@ module.exports = (config) => {
         ],
       },
       stats: { colors: true, reasons: true },
-      debug: true,
+      debug: false,
       plugins: [],
       postcss: postcssInit,
     },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,7 +43,7 @@ module.exports = (config) => {
     webpack: {
       entry: './src/tests.entry.ts',
       devtool: 'inline-source-map',
-      verbose: true,
+      verbose: false,
       resolve: {
         extensions: ['', '.webpack.js', '.web.js', '.ts', '.js'],
       },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,17 +7,36 @@ module.exports = (config) => {
   config.set({
     frameworks: [
       'jasmine',
-      'source-map-support',
     ],
 
-    files: ['./src/tests.entry.ts'],
+    plugins: [
+      'karma-jasmine',
+      'karma-sourcemap-writer',
+      'karma-sourcemap-loader',
+      'karma-webpack',
+      'karma-coverage',
+      'karma-spec-reporter',
+      'karma-chrome-launcher',
+    ],
+
+    files: [
+      './src/tests.entry.ts',
+      {
+        pattern: '**/*.map',
+        served: true,
+        included: false,
+        watched: true,
+      },
+    ],
 
     preprocessors: {
       './src/**/*.ts': [
         'webpack',
+        'sourcemap',
       ],
       './src/**/!(*.test|tests.*).ts': [
         'coverage',
+        'sourcemap',
       ],
     },
 
@@ -29,11 +48,7 @@ module.exports = (config) => {
         extensions: ['', '.webpack.js', '.web.js', '.ts', '.js'],
       },
       module: {
-        loaders: [
-          loaders.tsTest,
-          loaders.svg,
-          loaders.css,
-        ],
+        loaders: combinedLoaders(),
         postLoaders: [
           loaders.istanbulInstrumenter,
         ],
@@ -54,7 +69,6 @@ module.exports = (config) => {
     coverageReporter: {
       reporters: [
         { type: 'json' },
-        { type: 'html' },
       ],
       dir: './coverage/',
       subdir: (browser) => {
@@ -71,3 +85,20 @@ module.exports = (config) => {
     singleRun: true,
   });
 };
+
+function combinedLoaders() {
+  return Object.keys(loaders).reduce(function reduce(aggregate, k) {
+    switch (k) {
+    case 'tslint': // intolerably slow
+      return aggregate;
+    case 'ts':
+    case 'tsTest':
+      return aggregate.concat([ // force inline source maps
+        Object.assign(loaders[k],
+          { query: { babelOptions: { sourceMaps: 'inline' } } })]);
+    default:
+      return aggregate.concat([loaders[k]]);
+    }
+  },
+  []);
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,7 @@
 'use strict';
 
+process.env.TEST = true;
+
 const loaders = require('./webpack/loaders');
 const postcssInit = require('./webpack/postcss');
 const plugins = require('./webpack/plugins');
@@ -56,7 +58,7 @@ module.exports = (config) => {
       },
       stats: { colors: true, reasons: true },
       debug: false,
-      plugins: plugins,
+      plugins,
       postcss: postcssInit,
     },
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "karma-chrome-launcher": "^1.0.1",
     "karma-coverage": "^1.0.0",
     "karma-jasmine": "^1.0.2",
-    "karma-source-map-support": "^1.1.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-sourcemap-writer": "^0.1.2",
     "karma-spec-reporter": "0.0.26",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "autoprefixer-core": "^6.0.1",
     "awesome-typescript-loader": "^0.19.0",
     "babel-core": "^6.9.1",
+    "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.9.0",
     "basscss": "^8.0.1",
     "basscss-addons": "^1.0.0-beta4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ import { ROUTER_PROVIDERS } from '@angular/router-deprecated';
 import { APP_BASE_HREF } from '@angular/common/index';
 import { RioSampleAppComponent } from './containers/sample-app';
 
-declare let __PRODUCTION__: any;
+declare const __PRODUCTION__: boolean;
+declare const __TEST__: boolean;
 
 if (__PRODUCTION__) {
   enableProdMode();
@@ -19,7 +20,9 @@ if (__PRODUCTION__) {
   require('zone.js/dist/long-stack-trace-zone');
 }
 
-bootstrap(RioSampleAppComponent, [
-  ROUTER_PROVIDERS,
-  provide(APP_BASE_HREF, { useValue: '/' })
-]);
+if (!__TEST__) {
+  bootstrap(RioSampleAppComponent, [
+    ROUTER_PROVIDERS,
+    provide(APP_BASE_HREF, { useValue: '/' })
+  ]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import 'core-js/es6';
 import 'core-js/es7/reflect';
 import 'ts-helpers';

--- a/src/tests.entry.ts
+++ b/src/tests.entry.ts
@@ -27,11 +27,7 @@ setBaseTestProviders(TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS,
   TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS);
 
 const environment: any = window || this;
-Object.assign(environment, {
-  __DEV__: true,
-  __PRODUCTION__: false,
-  __TEST__: true
-});
+Object.assign(environment, { __TEST__: true });
 
 import './index.ts';
 

--- a/src/tests.entry.ts
+++ b/src/tests.entry.ts
@@ -27,7 +27,7 @@ setBaseTestProviders(TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS,
   TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS);
 
 const environment: any = window || this;
-Object.assign(environment, { // various third-party libraries depend on these
+Object.assign(environment, {
   __DEV__: true,
   __PRODUCTION__: false,
   __TEST__: true

--- a/src/tests.entry.ts
+++ b/src/tests.entry.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import 'babel-polyfill';
 import 'core-js/es6';
 import 'core-js/es7/reflect';
 import 'reflect-metadata';

--- a/src/tests.entry.ts
+++ b/src/tests.entry.ts
@@ -26,10 +26,16 @@ import {
 setBaseTestProviders(TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS,
   TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS);
 
-const looseRequire: any = require;
+const environment: any = window || this;
+Object.assign(environment, { // various third-party libraries depend on these
+  __DEV__: true,
+  __PRODUCTION__: false,
+  __TEST__: true
+});
 
-const testContext = looseRequire.context(
-  './',
-  true,
-  /\.test\.ts/);
+import './index.ts';
+
+const testContext = (<{ context?: Function }>require)
+  .context('./', true, /\.test\.ts$/);
+
 testContext.keys().forEach(testContext);

--- a/src/tests.entry.ts
+++ b/src/tests.entry.ts
@@ -26,9 +26,6 @@ import {
 setBaseTestProviders(TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS,
   TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS);
 
-const environment: any = window || this;
-Object.assign(environment, { __TEST__: true });
-
 import './index.ts';
 
 const testContext = (<{ context?: Function }>require)

--- a/webpack/loaders.js
+++ b/webpack/loaders.js
@@ -16,11 +16,6 @@ function loadTs(loader, inTest) {
     loader: loader || 'awesome-typescript-loader',
     exclude: inTest ? /node_modules/ :
       /(node_modules\/|\.test\.ts$|tests\.\w+\.ts$)/,
-    query: {
-      babelOptions: {
-        sourceMaps: inTest ? 'inline' : null,
-      },
-    },
   };
 }
 

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -9,6 +9,7 @@ const basePlugins = [
   new webpack.DefinePlugin({
     __DEV__: process.env.NODE_ENV !== 'production',
     __PRODUCTION__: process.env.NODE_ENV === 'production',
+    __TEST__: false,
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
   }),
   new SplitByPathPlugin([

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -9,7 +9,7 @@ const basePlugins = [
   new webpack.DefinePlugin({
     __DEV__: process.env.NODE_ENV !== 'production',
     __PRODUCTION__: process.env.NODE_ENV === 'production',
-    __TEST__: false,
+    __TEST__: process.env.TEST === true,
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
   }),
   new SplitByPathPlugin([

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -9,7 +9,7 @@ const basePlugins = [
   new webpack.DefinePlugin({
     __DEV__: process.env.NODE_ENV !== 'production',
     __PRODUCTION__: process.env.NODE_ENV === 'production',
-    __TEST__: process.env.TEST === true,
+    __TEST__: JSON.stringify(process.env.TEST || false),
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
   }),
   new SplitByPathPlugin([


### PR DESCRIPTION
This fixes the code coverage report:
  - The numbers are now correct
  - All source files are included, even if they aren't used by the tests
  - Source maps are used properly so that you get coverage information on the original TypeScript code

Connected to rangle/rangle-starter#92