### PR TITLE
Get proper code coverage reporting set up

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "cross-env NODE_ENV=production http-server ./dist",
     "pretest": "rimraf coverage/ & npm run lint",
     "test": "karma start --singleRun true",
-    "posttest": "npm run cover",
+    "posttest": "npm run cover && http-server ./coverage/",
     "test:watch": "karma start --singleRun false"
   },
   "repository": {
@@ -102,7 +102,7 @@
     "tslint": "^3.12.1",
     "tslint-loader": "^2.1.0",
     "typescript": "^2.0.0",
-    "webpack": "^2.1.0-beta.21",
+    "webpack": "2.1.0-beta.22",
     "webpack-dev-server": "^2.1.0-beta.0",
     "webpack-hot-middleware": "^2.12.2",
     "webpack-split-by-path": "^0.1.0-beta.1",


### PR DESCRIPTION
Connected to [rangle/rangle-starter#169](https://github.com/rangle/rangle-starter/issues/169).

It seems current angular-starter project already has the coverage folder after run test, so I just let http-server serve the report for user's review. 