### PR TITLE
Upgrade to Angular 2.0.0 final, webpack 2.1.0-beta.25, and fix HTML coverage reports

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,6 @@
 process.env.TEST = true;
 
 const loaders = require('./webpack/loaders');
-const postcssInit = require('./webpack/postcss');
 const plugins = require('./webpack/plugins');
 
 module.exports = (config) => {
@@ -48,20 +47,18 @@ module.exports = (config) => {
     webpack: {
       entry: './src/tests.entry.ts',
       devtool: 'inline-source-map',
-      verbose: false,
       resolve: {
-        extensions: ['', '.webpack.js', '.web.js', '.ts', '.js'],
+        extensions: ['.webpack.js', '.web.js', '.ts', '.js'],
       },
       module: {
-        loaders: combinedLoaders(),
-        postLoaders: config.singleRun
-          ? [ loaders.istanbulInstrumenter ]
-          : [ ],
+        rules:
+          combinedLoaders().concat(
+            config.singleRun
+              ? [ loaders.istanbulInstrumenter ]
+              : [ ]),
       },
       stats: { colors: true, reasons: true },
-      debug: false,
       plugins,
-      postcss: postcssInit,
     },
 
     webpackServer: {
@@ -72,13 +69,6 @@ module.exports = (config) => {
       .concat(coverage)
       .concat(coverage.length > 0 ? ['karma-remap-istanbul'] : []),
 
-    remapIstanbulReporter: {
-      src: 'coverage/chrome/coverage-final.json',
-      reports: {
-        html: 'coverage',
-      },
-    },
-
     // only output json report to be remapped by remap-istanbul
     coverageReporter: {
       reporters: [
@@ -88,6 +78,14 @@ module.exports = (config) => {
       subdir: (browser) => {
         return browser.toLowerCase().split(/[ /-]/)[0]; // returns 'chrome'
       },
+    },
+
+    remapIstanbulReporter: {
+      src: './coverage/chrome/coverage-final.json',
+      reports: {
+        html: 'coverage',
+      },
+      timeoutNotCreated: 5000,
     },
 
     port: 9999,

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "http-server": "^0.9.0"
   },
   "devDependencies": {
-    "@angular/common": "2.0.0-rc.6",
-    "@angular/compiler": "2.0.0-rc.6",
-    "@angular/core": "2.0.0-rc.6",
-    "@angular/http": "2.0.0-rc.6",
-    "@angular/platform-browser": "2.0.0-rc.6",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.6",
+    "@angular/common": "2.0.0",
+    "@angular/compiler": "2.0.0",
+    "@angular/core": "2.0.0",
+    "@angular/http": "2.0.0",
+    "@angular/platform-browser": "2.0.0",
+    "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "^3.0.0-rc.2",
     "autoprefixer": "^6.3.3",
     "awesome-typescript-loader": "^2.2.3",
@@ -92,7 +92,7 @@
     "raw-loader": "^0.5.1",
     "reflect-metadata": "0.1.8",
     "rimraf": "^2.5.4",
-    "rxjs": "5.0.0-beta.11",
+    "rxjs": "5.0.0-beta.12",
     "selenium-standalone": "^5.6.2",
     "style-loader": "^0.13.0",
     "stylelint": "^7.2.0",
@@ -102,10 +102,10 @@
     "tslint": "^3.12.1",
     "tslint-loader": "^2.1.0",
     "typescript": "^2.0.0",
-    "webpack": "^2.1.0-beta.21",
-    "webpack-dev-server": "^2.1.0-beta.0",
-    "webpack-hot-middleware": "^2.12.2",
-    "webpack-split-by-path": "^0.1.0-beta.1",
+    "webpack": "2.1.0-beta.25",
+    "webpack-dev-server": "2.1.0-beta.5",
+    "webpack-hot-middleware": "2.12.2",
+    "webpack-split-by-path": "0.1.0-beta.1",
     "zone.js": "^0.6.17"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const loaders = require('./webpack/loaders');
 const plugins = require('./webpack/plugins');
-const postcssInit = require('./webpack/postcss');
 
 module.exports = {
   entry: {
@@ -20,7 +19,6 @@ module.exports = {
       'core-js',
       'rxjs',
       'immutable',
-      'zone.js',
     ],
   },
 
@@ -36,10 +34,8 @@ module.exports = {
     'source-map' :
     'inline-source-map',
 
-  postcss: postcssInit,
-
   resolve: {
-    extensions: ['', '.webpack.js', '.web.js', '.ts', '.js'],
+    extensions: ['.webpack.js', '.web.js', '.ts', '.js'],
   },
 
   plugins: plugins,
@@ -50,10 +46,9 @@ module.exports = {
   },
 
   module: {
-    preLoaders: [
+    rules: [
+      loaders.angular,
       loaders.tslint,
-    ],
-    loaders: [
       loaders.ts,
       loaders.html,
       loaders.css,

--- a/webpack/loaders.js
+++ b/webpack/loaders.js
@@ -1,6 +1,17 @@
 'use strict';
 
+exports.angular = { // ships in ES6 format now
+  test: /\.js$/,
+  loader: 'babel-loader',
+  include: /angular/,
+  exclude: /node_modules/,
+  query: {
+    compact: false,
+  },
+};
+
 exports.tslint = {
+  enforce: 'pre',
   test: /\.ts$/,
   loader: 'tslint',
   exclude: /node_modules/,
@@ -13,11 +24,9 @@ exports.ts = {
 };
 
 exports.istanbulInstrumenter = {
+  enforce: 'post',
   test: /^(.(?!\.test))*\.ts$/,
   loader: 'istanbul-instrumenter-loader',
-  query: {
-    embedSource: true,
-  },
 };
 
 exports.html = {

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -5,6 +5,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const StyleLintPlugin = require('stylelint-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
+const postcss = require('./postcss');
+
 const sourceMap = process.env.TEST
   ? [new webpack.SourceMapDevToolPlugin({ filename: null, test: /\.ts$/ })]
   : [];
@@ -25,6 +27,14 @@ const basePlugins = [
   new CopyWebpackPlugin([
     { from: 'src/assets', to: 'assets' },
   ]),
+  new webpack.LoaderOptionsPlugin({
+    test: /\.css$/,
+    options: {
+      postcss,
+    },
+  }),
+  new webpack.ContextReplacementPlugin(
+    /angular\/core\/(esm\/src|src)\/linker/, __dirname),
 ].concat(sourceMap);
 
 const devPlugins = [


### PR DESCRIPTION
Upgrade to Angular 2.0.0 final
Upgrade to webpack 2.1.0-beta.25
Resolve issue with HTML code coverage reports not being generated