### PR TITLE
Remove unneeded noParse build rules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,5 @@ module.exports = {
       loaders.woff2,
       loaders.ttf,
     ],
-    noParse: [/zone\.js\/dist\/.+/, /angular2\/bundles\/.+/],
   },
 };


### PR DESCRIPTION
Removes reference to old beta bundles and no longer needed ZoneJS work around