### PR TITLE
Remove the leading '.' in the entryModule path

### DIFF
--- a/webpack-aot.config.js
+++ b/webpack-aot.config.js
@@ -21,7 +21,7 @@ webpackConfig.module.rules = [
 webpackConfig.plugins = webpackConfig.plugins.concat([
   new AotPlugin({
     tsConfigPath: './tsconfig-aot.json',
-    entryModule: './src/app/app.module#AppModule',
+    entryModule: 'src/app/app.module#AppModule',
   }),
 ]);
 if (!JiT) {


### PR DESCRIPTION
The path passed to entryModule should not be in a relative style, otherwise AoTPlugin cannot parse the correct location of NgModules which leads to errors when use lazy-loading. Take a look at [here](https://github.com/angular/angular-cli/blob/457a6e09d68eeddfafc6e843352ca5359228a5d7/packages/webpack/src/plugin.ts#L296).