### PR TITLE
fix for missing source map

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:jit": "cross-env NODE_ENV=production webpack",
     "clean": "rimraf dist/",
     "cover": "istanbul report text text-summary",
-    "dev": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot --progress --no-info",
+    "dev": "cross-env NODE_ENV=development webpack-dev-server --debug --inline --hot --progress --no-info",
     "lint": "npm run lint-ts && npm run lint-js && npm run lint-css",
     "lint-ts": "tslint './src/**/*.ts'",
     "lint-js": "eslint '**/*.js' --ignore-path .gitignore",

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -56,6 +56,7 @@ const prodPlugins = [
     ],
   }),
   new webpack.optimize.UglifyJsPlugin({
+    sourceMap: true,
     mangle: {
       keep_fnames: true,
     },


### PR DESCRIPTION
UglifyJsPlugin had its default config changed, it now requires sourceMap: true to not filter them out