### PR TITLE
fix for cross-env to be an actual dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "url": "https://github.com/rangle/angular2-redux-starter/issues"
   },
   "dependencies": {
+    "cross-env": "^3.1.3",
     "http-server": "^0.9.0"
   },
   "devDependencies": {
@@ -65,7 +66,6 @@
     "console-polyfill": "^0.2.3",
     "copy-webpack-plugin": "^4.0.0",
     "core-js": "^2.4.1",
-    "cross-env": "^3.1.3",
     "css-loader": "^0.26.1",
     "cssnano": "^3.7.7",
     "es7-reflect-metadata": "^1.6.0",


### PR DESCRIPTION
to be able to run the `npm start` script without any devDependencies (ie. after a prune)