### PR TITLE
Removed code that is no longer needed

### DIFF
--- a/tsconfig-aot.json
+++ b/tsconfig-aot.json
@@ -20,9 +20,6 @@
       "core-js"
     ]
   },
-  "angularCompilerOptions": {
-    "entryModule": "app/app.module#AppModule"
-  },
   "exclude": [
     "node_modules",
     "dist",

--- a/webpack-aot.config.js
+++ b/webpack-aot.config.js
@@ -5,7 +5,6 @@ const loaders = require('./webpack/loaders');
 const AotPlugin =  require('@ngtools/webpack').AotPlugin;
 
 webpackConfig.module.rules = [
-  loaders.tslint,
   loaders.ts,
   loaders.html,
   { test: /\.css$/, use: 'raw-loader', include: /node_modules/ },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,6 @@ module.exports = {
 
   module: {
     rules: [
-      loaders.angular,
       loaders.tslint,
       loaders.ts_JiT,
       loaders.html,

--- a/webpack/loaders.js
+++ b/webpack/loaders.js
@@ -3,18 +3,6 @@
 const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
-exports.angular = { // ships in ES6 format now
-  test: /\.js$/,
-  use: [
-    {
-      loader: 'babel-loader',
-      options: { compact: false },
-    },
-  ],
-  include: /angular/,
-  exclude: /node_modules/,
-};
-
 exports.tslint = {
   enforce: 'pre',
   test: /\.ts$/,


### PR DESCRIPTION
- Loading angular through babel is no longer required
- Removed `angularCompilerOptions` from tsconfig-aot
- Disabled tslint loader during AoT build since the linter runs during test task already.